### PR TITLE
SSH support + QoL improvements (hopefully!)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ eframe = { version = "0.22.0", default-features = false, features = [
 egui_extras = { version="0.22.0" }
 egui_glow = "0.22.0"
 glow = "0.12.2"
+dark-light = "1.0.0"
 
 #sound
 cpal = "0.15.2"
@@ -50,7 +51,7 @@ env_logger = "0.9.0"
 web-time = "0.2.0"
 # possible ssh options:
 
-# libssh-rs =  { version = "0.2.0", features = ["vendored", "vendored-openssl"] }
+libssh-rs =  { version = "0.2.0", features = ["vendored", "vendored-openssl"] }
 
 # thrussh = "0.34.0"
 # thrussh-keys = "0.22.1"

--- a/src/com/mod.rs
+++ b/src/com/mod.rs
@@ -15,8 +15,7 @@ pub use telnet::*;
 
 pub mod raw;
 pub use raw::*;
-
-// pub mod ssh;
+pub mod ssh;
 
 use crate::{
     addresses::{Address, Terminal},
@@ -26,6 +25,7 @@ pub type TermComResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
 
 pub trait Com: Sync + Send {
     fn get_name(&self) -> &'static str;
+    fn default_port(&self) -> u16;
 
     fn send(&mut self, buf: &[u8]) -> TermComResult<usize>;
     fn connect(&mut self, addr: &Address, timeout: Duration) -> TermComResult<bool>;

--- a/src/com/raw.rs
+++ b/src/com/raw.rs
@@ -23,6 +23,11 @@ impl Com for ComRawImpl {
     fn get_name(&self) -> &'static str {
         "Raw"
     }
+
+    fn default_port(&self) -> u16 {
+        0
+    }
+
     fn set_terminal_type(&mut self, _terminal: crate::addresses::Terminal) {}
 
     fn connect(&mut self, addr: &Address, _timeout: Duration) -> TermComResult<bool> {

--- a/src/com/ssh.rs
+++ b/src/com/ssh.rs
@@ -30,15 +30,15 @@ impl SSHComImpl {
     }
 
     fn parse_address(addr: &Address) -> TermComResult<(String, u16)> {
-        let components: Vec<&str> = addr.address.split(":").collect();
-        match components.get(0) {
+        let components: Vec<&str> = addr.address.split(':').collect();
+        match components.first() {
             Some(host) => {
                 match components.get(1) {
                     Some(port_str) => {
                         let port = port_str.parse()?;
-                        Ok((host.to_string(), port))
+                        Ok(((*host).to_string(), port))
                     }
-                    _ => Ok((host.to_string(),  Self::default_port()))
+                    _ => Ok(((*host).to_string(),  Self::default_port()))
                 }
             }
             _ => Err(Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid address")))
@@ -64,9 +64,6 @@ impl Com for SSHComImpl {
 
         sess.set_option(SshOption::Hostname(host))?;
         sess.set_option(SshOption::Port(port))?;
-        // sess.set_option(SshOption::PublicKeyAcceptedTypes(
-        //     ACCEPTED_PK_TYPES.to_string(),
-        // ))?;
         sess.options_parse_config(None)?;
         sess.connect()?;
 
@@ -115,10 +112,10 @@ impl Com for SSHComImpl {
         Ok(Vec::new())
     }
 
-    fn send<'a>(&mut self, buf: &'a [u8]) -> TermComResult<usize> {
+    fn send(&mut self, buf: &[u8]) -> TermComResult<usize> {
         let channel = self.channel.as_mut().unwrap().clone();
         let locked = channel.lock().unwrap();
-        locked.stdin().write_all(&buf)?;
+        locked.stdin().write_all(buf)?;
         Ok(buf.len())
     }
 

--- a/src/com/telnet.rs
+++ b/src/com/telnet.rs
@@ -510,6 +510,11 @@ impl Com for ComTelnetImpl {
     fn get_name(&self) -> &'static str {
         "Telnet"
     }
+
+    fn default_port(&self) -> u16 {
+        23
+    }
+
     fn set_terminal_type(&mut self, terminal: crate::addresses::Terminal) {
         self.terminal = terminal;
     }

--- a/src/com/telnet.rs
+++ b/src/com/telnet.rs
@@ -347,6 +347,7 @@ impl ComTelnetImpl {
                                 ];
 
                                 match self.terminal {
+                                    //  :TODO: Let's extend this to allow for some of the semi-standard BBS IDs, e.g. "xterm" (ANSI), "ansi-256-color", etc.
                                     Terminal::Ansi => buf.extend_from_slice(b"ANSI"),
                                     Terminal::PETscii => buf.extend_from_slice(b"PETSCII"),
                                     Terminal::ATAscii => buf.extend_from_slice(b"ATASCII"),
@@ -366,7 +367,7 @@ impl ComTelnetImpl {
                             }
                         }
                         24 => {
-                            // Ternminal type
+                            // Terminal type
                             self.state =
                                 ParserState::SubCommand(telnet_option::TerminalType as i32);
                         }

--- a/src/data/addresses.rs
+++ b/src/data/addresses.rs
@@ -63,8 +63,7 @@ impl Display for Protocol {
 }
 
 impl Protocol {
-    pub const ALL: [Protocol; 2] = [Protocol::Telnet, Protocol::Raw];
-    //pub const ALL: [Protocol; 3] = [Protocol::Telnet, Protocol::Raw, Protocol::Ssh];
+    pub const ALL: [Protocol; 3] = [Protocol::Telnet, Protocol::Raw, Protocol::Ssh];
 }
 
 #[derive(Debug, Clone)]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -93,6 +93,9 @@ impl MainWindow {
         */
         let ctx = &cc.egui_ctx;
 
+        // try to detect dark vs light mode from the host system; default to dark
+        ctx.set_visuals(if dark_light::detect() == dark_light::Mode::Light { egui::Visuals::light() } else { egui::Visuals::dark() });
+
         let mut style: egui::Style = (*ctx.style()).clone();
         style.spacing.window_margin = egui::Margin::same(8.0);
         //        style.spacing.button_padding = Vec2::new(4., 2.);

--- a/src/ui/dialogs/phonebook_dialog.rs
+++ b/src/ui/dialogs/phonebook_dialog.rs
@@ -740,12 +740,10 @@ impl egui::Widget for AddressRow {
             star_text.into_galley(ui, Some(false), wrap_width, egui::TextStyle::Button);
         let star_text_size = star_text.size();
 
-        let mut rt = RichText::new(addr.system_name.clone())
+        let rt = RichText::new(addr.system_name.clone())
             .font(FontId::new(16., FontFamily::Proportional))
             .strong();
-        if !centered {
-            rt = rt.color(Color32::WHITE);
-        }
+
         let name_text = WidgetText::from(rt);
         let name_text = name_text.into_galley(ui, Some(false), wrap_width, egui::TextStyle::Button);
         let name_text_size = name_text.size();

--- a/src/ui/dialogs/up_download_dialog.rs
+++ b/src/ui/dialogs/up_download_dialog.rs
@@ -84,7 +84,7 @@ impl FileTransferDialog {
                                 "transfer-protocol"
                             )));
                             ui.label(
-                                RichText::new(state.protocol_name.clone()).color(Color32::WHITE),
+                                RichText::new(state.protocol_name.clone()),
                             );
                         });
                     });
@@ -95,7 +95,7 @@ impl FileTransferDialog {
                                 crate::LANGUAGE_LOADER,
                                 "transfer-checksize"
                             )));
-                            ui.label(RichText::new(check).color(Color32::WHITE));
+                            ui.label(RichText::new(check));
                         });
 
                         row.col(|ui| {
@@ -103,14 +103,14 @@ impl FileTransferDialog {
                                 crate::LANGUAGE_LOADER,
                                 "transfer-elapsedtime"
                             )));
-                            ui.label(RichText::new(elapsed_time).color(Color32::WHITE));
+                            ui.label(RichText::new(elapsed_time));
                         });
                     });
                 });
 
                 ui.horizontal(|ui| {
                     ui.label(RichText::new(fl!(crate::LANGUAGE_LOADER, "transfer-file")));
-                    ui.label(RichText::new(file_name).color(Color32::WHITE));
+                    ui.label(RichText::new(file_name));
                 });
                 ui.add(
                     ProgressBar::new(
@@ -127,8 +127,7 @@ impl FileTransferDialog {
                     ui.label(RichText::new(fl!(crate::LANGUAGE_LOADER, "transfer-rate")));
                     let bps = bb.bytes(transfer_info.get_bps()).to_string();
                     ui.label(
-                        RichText::new(fl!(crate::LANGUAGE_LOADER, "transfer-bps", bps = bps))
-                            .color(Color32::WHITE),
+                        RichText::new(fl!(crate::LANGUAGE_LOADER, "transfer-bps", bps = bps)),
                     );
                 });
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,7 +20,7 @@ use crate::util::{beep, play_music, Rng};
 use crate::Options;
 use crate::{
     addresses::{store_phone_book, Address},
-    com::{ComRawImpl, ComTelnetImpl, SendData},
+    com::{ComRawImpl, ComTelnetImpl, ssh::SSHComImpl, SendData},
     protocol::FileDescriptor,
     TerminalResult,
 };
@@ -39,8 +39,8 @@ pub use terminal_window::*;
 
 pub mod util;
 pub use util::*;
-
 pub mod dialogs;
+
 
 // pub mod simulate;
 
@@ -331,7 +331,7 @@ impl MainWindow {
             let mut com: Box<dyn Com> = match ct {
                 crate::addresses::Protocol::Telnet => Box::new(ComTelnetImpl::new(window_size)),
                 crate::addresses::Protocol::Raw => Box::new(ComRawImpl::new()),
-                crate::addresses::Protocol::Ssh => panic!(), //Box::new(crate::com::SSHCom::new()),
+                crate::addresses::Protocol::Ssh => Box::new(SSHComImpl::new(window_size)),
             };
             if let Err(err) = com.connect(&call_adr, timeout) {
                 Err(err)


### PR DESCRIPTION
🚧 WORK IN PROGRESS SSH SUPPORT 🚧
I can connect + handshake and display incoming data. I didn't have time to really look yet, but I think we're now in the recv blocking vs send (ie: need two threads) zone.

Try to detect dark vs light OS theme/mode & apply; default to dark. Let me know if this works for you. For me, I get the white lettering on dark in dark mode & black lettering on white in light mode.

Put a little note in there for discussion RE: TerminalType - if we allow for e.g. "ansi-bbs-256color", "xterm-truecolor", etc., some boards will try to use extended abilities. 

