### PR TITLE
Websocket support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ dark-light = "1.0.0"
 
 #sound
 rodio = "0.17.1"
-#icy_engine = { git ="https://github.com/mkrueger/icy_engine" }
-icy_engine = { path = "../icy_engine" }
+icy_engine = { git ="https://github.com/mkrueger/icy_engine" }
+#icy_engine = { path = "../icy_engine" }
 
 walkdir = "2"
 toml = "0.7.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ dark-light = "1.0.0"
 
 #sound
 rodio = "0.17.1"
-icy_engine = { git ="https://github.com/mkrueger/icy_engine" }
-#icy_engine = { path = "../icy_engine" }
+#icy_engine = { git ="https://github.com/mkrueger/icy_engine" }
+icy_engine = { path = "../icy_engine" }
 
 walkdir = "2"
 toml = "0.7.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ dark-light = "1.0.0"
 
 #sound
 rodio = "0.17.1"
-icy_engine = { git ="https://github.com/mkrueger/icy_engine" }
-#icy_engine = { path = "../icy_engine" }
+#icy_engine = { git ="https://github.com/mkrueger/icy_engine" }
+icy_engine = { path = "../icy_engine" }
 
 walkdir = "2"
 toml = "0.7.6"
@@ -49,6 +49,20 @@ once_cell = "1.18.0"
 log = "0.4"
 env_logger = "0.9.0"
 web-time = "0.2.0"
+
+# WebSocket support
+tungstenite = { version = "0.20.0", features = [
+    "rustls-tls-webpki-roots", # webpki root CAs
+    "__rustls-tls",            # use Rustls
+]}
+
+http = "0.2.9"
+url = "2.4.0"
+rustls = { version = "0.21.6", features = [
+    "tls12",
+    "dangerous_configuration"  # Allow invalid certs/etc.
+]}
+webpki-roots = "0.25.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 directories = "5.0.1"

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Features supported so far:
   - [x] Telnet
   - [x] SSH
   - [x] Raw
+  - [x] WebSockets (both secure and non-secure)
 - Terminal encoding support
-  - [x] Ansi
-    - Ansi music
+  - [x] ANSI
+    - ANSI music
     - Sixel support
     - Loadable fonts
   - [x] Avatar

--- a/src/com/mod.rs
+++ b/src/com/mod.rs
@@ -11,6 +11,8 @@ pub use telnet::*;
 pub mod raw;
 pub use raw::*;
 
+pub mod websocket;
+
 #[cfg(not(target_arch = "wasm32"))]
 pub mod ssh;
 

--- a/src/com/ssh.rs
+++ b/src/com/ssh.rs
@@ -83,9 +83,7 @@ impl Com for SSHComImpl {
         SSHComImpl::default_port()
     }
 
-    fn set_terminal_type(&mut self, _terminal: crate::addresses::Terminal) {
-
-    }
+    fn set_terminal_type(&mut self, _terminal: crate::addresses::Terminal) {}
 
     fn read_data(&mut self) -> TermComResult<Option<Vec<u8>>> {
         let mut buf = [0; 1024 * 256];
@@ -118,9 +116,7 @@ impl Com for SSHComImpl {
             Ok(locked) => {
                 let mut stdout = locked.stdout();
                 match stdout.read(&mut buf) {
-                    Ok(_) => {
-                        Ok(buf[0])
-                    }
+                    Ok(_) => Ok(buf[0]),
                     Err(err) => {
                         return Err(Box::new(std::io::Error::new(
                             ErrorKind::ConnectionAborted,

--- a/src/com/ssh.rs
+++ b/src/com/ssh.rs
@@ -118,10 +118,10 @@ impl Com for SSHComImpl {
                 match stdout.read(&mut buf) {
                     Ok(_) => Ok(buf[0]),
                     Err(err) => {
-                        return Err(Box::new(std::io::Error::new(
+                        Err(Box::new(std::io::Error::new(
                             ErrorKind::ConnectionAborted,
                             format!("error while reading single byte from stream: {err}"),
-                        )));
+                        )))
                     }
                 }
             }

--- a/src/com/ssh.rs
+++ b/src/com/ssh.rs
@@ -117,12 +117,10 @@ impl Com for SSHComImpl {
                 let mut stdout = locked.stdout();
                 match stdout.read(&mut buf) {
                     Ok(_) => Ok(buf[0]),
-                    Err(err) => {
-                        Err(Box::new(std::io::Error::new(
-                            ErrorKind::ConnectionAborted,
-                            format!("error while reading single byte from stream: {err}"),
-                        )))
-                    }
+                    Err(err) => Err(Box::new(std::io::Error::new(
+                        ErrorKind::ConnectionAborted,
+                        format!("error while reading single byte from stream: {err}"),
+                    ))),
                 }
             }
             Err(err) => Err(Box::new(std::io::Error::new(

--- a/src/com/ssh.rs
+++ b/src/com/ssh.rs
@@ -83,7 +83,9 @@ impl Com for SSHComImpl {
         SSHComImpl::default_port()
     }
 
-    fn set_terminal_type(&mut self, _terminal: crate::addresses::Terminal) {}
+    fn set_terminal_type(&mut self, _terminal: crate::addresses::Terminal) {
+
+    }
 
     fn read_data(&mut self) -> TermComResult<Option<Vec<u8>>> {
         let mut buf = [0; 1024 * 256];
@@ -116,7 +118,7 @@ impl Com for SSHComImpl {
             Ok(locked) => {
                 let mut stdout = locked.stdout();
                 match stdout.read(&mut buf) {
-                    Ok(size) => {
+                    Ok(_) => {
                         Ok(buf[0])
                     }
                     Err(err) => {

--- a/src/com/websocket.rs
+++ b/src/com/websocket.rs
@@ -1,0 +1,132 @@
+use crate::addresses;
+use std::borrow::BorrowMut;
+use std::sync::Arc;
+
+use super::{Com, OpenConnectionData, TermComResult};
+
+use rustls::{OwnedTrustAnchor, RootCertStore};
+use tungstenite::{client::IntoClientRequest, WebSocket, stream::MaybeTlsStream, Error, Message};
+use std::net::TcpStream;
+use std::io::ErrorKind;
+use http::Uri;
+
+struct NoCertVerifier {}
+
+impl rustls::client::ServerCertVerifier for NoCertVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &rustls::Certificate,
+        intermediates: &[rustls::Certificate],
+        server_name: &rustls::ServerName,
+        scts: &mut dyn Iterator<Item = &[u8]>,
+        ocsp_response: &[u8],
+        now: std::time::SystemTime,
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error>
+    {
+        Ok(rustls::client::ServerCertVerified::assertion())
+    }
+}
+pub struct WebSocketComImpl {
+    socket: WebSocket<MaybeTlsStream<TcpStream>>
+}
+
+
+impl WebSocketComImpl {
+    pub fn connect(connection_data: &OpenConnectionData) -> TermComResult<Self> {
+        let is_secure = connection_data.protocol == addresses::Protocol::WebSocket(true);
+
+        // build an ws:// or wss:// address
+        //  :TODO: default port if not supplied in address
+        let url = format!("{}://{}", Self::schema_prefix(is_secure), connection_data.address);
+        let uri = Uri::try_from(url)?;
+
+        let mut root_store = RootCertStore::empty();
+        root_store.add_trust_anchors(
+            webpki_roots::TLS_SERVER_ROOTS
+                .iter()
+                .map(|ta| {
+                    OwnedTrustAnchor::from_subject_spki_name_constraints(
+                        ta.subject,
+                        ta.spki,
+                        ta.name_constraints,
+                    )
+                }),
+        );
+
+        let mut config = rustls::ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+
+        // enable this line to test non-secure (ie: invalid certs) wss:// -- we could make this an option in the UI
+        //config.dangerous().set_certificate_verifier(Arc::new(NoCertVerifier{}));
+
+        let config = Arc::new(config);
+
+        let stream = TcpStream::connect(connection_data.address.clone())?;
+        let connector: tungstenite::Connector = tungstenite::Connector::Rustls(config);
+        let (mut socket, _) = tungstenite::client_tls_with_config(uri.into_client_request()?, stream, None, Some(connector))?;
+
+        let s = socket.get_mut();
+        match s {
+            MaybeTlsStream::Plain(s) => {
+                s.set_nonblocking(true)?;
+            }
+            MaybeTlsStream::Rustls(tls) => {
+                tls.sock.set_nonblocking(true)?;
+            },
+            _ => ()
+        }
+
+        Ok(Self{socket})
+    }
+
+    fn schema_prefix(is_secure: bool) -> &'static str {
+        match is_secure {
+            true => "wss",
+            false => "ws"
+        }
+    }
+}
+
+impl Com for WebSocketComImpl {
+    fn get_name(&self) -> &'static str {
+        "WebSocket"
+    }
+
+    fn default_port(&self) -> u16 {
+        443 // generally secure by default
+    }
+
+    fn set_terminal_type(&mut self, _terminal: crate::addresses::Terminal) {}
+
+    fn read_data(&mut self) -> TermComResult<Option<Vec<u8>>> {
+        match self.socket.read() {
+            Ok(msg) => Ok(Some(msg.into_data())),
+            Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+            Err(e) =>
+                Err(Box::new(std::io::Error::new(
+                    ErrorKind::ConnectionAborted,
+                    format!("Connection aborted: {e}"),
+                )))
+        }
+    }
+
+    fn read_u8(&mut self) -> TermComResult<u8> {
+        Ok(0)
+    }
+
+    fn read_exact(&mut self, len: usize) -> TermComResult<Vec<u8>> {
+        Ok(vec![0])
+    }
+
+    fn send(&mut self, buf: &[u8]) -> TermComResult<usize> {
+        let msg = Message::binary(buf);
+        self.socket.send(msg)?; // write + flush
+        Ok(buf.len())
+    }
+
+    fn disconnect(&mut self) -> TermComResult<()> {
+        Ok(self.socket.close(None)?)
+    }
+}

--- a/src/com/websocket.rs
+++ b/src/com/websocket.rs
@@ -81,7 +81,11 @@ impl WebSocketComImpl {
     }
 
     fn schema_prefix(is_secure: bool) -> &'static str {
-        if is_secure { "wss" } else { "ws" }
+        if is_secure {
+            "wss"
+        } else {
+            "ws"
+        }
     }
 }
 

--- a/src/com/websocket.rs
+++ b/src/com/websocket.rs
@@ -1,5 +1,4 @@
 use crate::addresses;
-use std::borrow::BorrowMut;
 use std::sync::Arc;
 
 use super::{Com, OpenConnectionData, TermComResult};
@@ -82,10 +81,7 @@ impl WebSocketComImpl {
     }
 
     fn schema_prefix(is_secure: bool) -> &'static str {
-        match is_secure {
-            true => "wss",
-            false => "ws",
-        }
+        if is_secure { "wss" } else { "ws" }
     }
 }
 
@@ -115,7 +111,7 @@ impl Com for WebSocketComImpl {
         Ok(0)
     }
 
-    fn read_exact(&mut self, len: usize) -> TermComResult<Vec<u8>> {
+    fn read_exact(&mut self, _len: usize) -> TermComResult<Vec<u8>> {
         Ok(vec![0])
     }
 

--- a/src/data/addresses.rs
+++ b/src/data/addresses.rs
@@ -54,19 +54,29 @@ pub enum Protocol {
     Telnet,
     Raw,
     Ssh,
+    WebSocket(bool), // true=secure
 }
 
 impl Display for Protocol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self:?}")
+        match self {
+            Self::Ssh => write!(f, "SSH"),
+            Self::WebSocket(is_secure) => {
+                match is_secure {
+                    true => write!(f, "Secure WebSocket"),
+                    false => write!(f, "WebSocket"),
+                }
+            }
+            _ => write!(f, "{self:?}")
+        }
     }
 }
 
 impl Protocol {
     #[cfg(not(target_arch = "wasm32"))]
-    pub const ALL: [Protocol; 3] = [Protocol::Telnet, Protocol::Raw, Protocol::Ssh];
+    pub const ALL: [Protocol; 5] = [Protocol::Telnet, Protocol::Raw, Protocol::Ssh, Protocol::WebSocket(true), Protocol::WebSocket(false)];
     #[cfg(target_arch = "wasm32")]
-    pub const ALL: [Protocol; 2] = [Protocol::Telnet, Protocol::Raw];
+    pub const ALL: [Protocol; 3] = [Protocol::Telnet, Protocol::Raw, Protocol::WebSocket(true)];
 }
 
 #[derive(Debug, Clone)]
@@ -408,6 +418,8 @@ fn parse_address(value: &Value) -> Address {
                 "telnet" => result.protocol = Protocol::Telnet,
                 "ssh" => result.protocol = Protocol::Ssh,
                 "raw" => result.protocol = Protocol::Raw,
+                "websocket(true)" => result.protocol = Protocol::WebSocket(true),
+                "websocket(false)" => result.protocol = Protocol::WebSocket(false),
                 _ => {}
             }
         }

--- a/src/data/addresses.rs
+++ b/src/data/addresses.rs
@@ -61,20 +61,24 @@ impl Display for Protocol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Ssh => write!(f, "SSH"),
-            Self::WebSocket(is_secure) => {
-                match is_secure {
-                    true => write!(f, "Secure WebSocket"),
-                    false => write!(f, "WebSocket"),
-                }
-            }
-            _ => write!(f, "{self:?}")
+            Self::WebSocket(is_secure) => match is_secure {
+                true => write!(f, "Secure WebSocket"),
+                false => write!(f, "WebSocket"),
+            },
+            _ => write!(f, "{self:?}"),
         }
     }
 }
 
 impl Protocol {
     #[cfg(not(target_arch = "wasm32"))]
-    pub const ALL: [Protocol; 5] = [Protocol::Telnet, Protocol::Raw, Protocol::Ssh, Protocol::WebSocket(true), Protocol::WebSocket(false)];
+    pub const ALL: [Protocol; 5] = [
+        Protocol::Telnet,
+        Protocol::Raw,
+        Protocol::Ssh,
+        Protocol::WebSocket(true),
+        Protocol::WebSocket(false),
+    ];
     #[cfg(target_arch = "wasm32")]
     pub const ALL: [Protocol; 3] = [Protocol::Telnet, Protocol::Raw, Protocol::WebSocket(true)];
 }

--- a/src/ui/com_thread.rs
+++ b/src/ui/com_thread.rs
@@ -92,6 +92,9 @@ impl ConnectionThreadData {
             crate::addresses::Protocol::Ssh => {
                 Box::new(crate::com::ssh::SSHComImpl::connect(connection_data)?)
             }
+            crate::addresses::Protocol::WebSocket(_) => {
+                Box::new(crate::com::websocket::WebSocketComImpl::connect(connection_data)?)
+            }
 
             #[cfg(target_arch = "wasm32")]
             crate::addresses::Protocol::Ssh => Box::new(crate::com::NullConnection {}),

--- a/src/ui/com_thread.rs
+++ b/src/ui/com_thread.rs
@@ -92,9 +92,9 @@ impl ConnectionThreadData {
             crate::addresses::Protocol::Ssh => {
                 Box::new(crate::com::ssh::SSHComImpl::connect(connection_data)?)
             }
-            crate::addresses::Protocol::WebSocket(_) => {
-                Box::new(crate::com::websocket::WebSocketComImpl::connect(connection_data)?)
-            }
+            crate::addresses::Protocol::WebSocket(_) => Box::new(
+                crate::com::websocket::WebSocketComImpl::connect(connection_data)?,
+            ),
 
             #[cfg(target_arch = "wasm32")]
             crate::addresses::Protocol::Ssh => Box::new(crate::com::NullConnection {}),

--- a/src/ui/dialogs/phonebook_dialog.rs
+++ b/src/ui/dialogs/phonebook_dialog.rs
@@ -252,11 +252,11 @@ fn render_quick_connect(window: &mut MainWindow, ui: &mut egui::Ui) {
             });
 
             egui::ComboBox::from_id_source("combobox1")
-                .selected_text(RichText::new(format!("{:?}", adr.protocol)))
+                .selected_text(RichText::new(format!("{}", adr.protocol)))
                 .show_ui(ui, |ui| {
-                    for ct in &addresses::Protocol::ALL {
-                        let label = RichText::new(format!("{ct:?}"));
-                        ui.selectable_value(&mut adr.protocol, *ct, label);
+                    for prot in &addresses::Protocol::ALL {
+                        let label = RichText::new(format!("{prot}"));
+                        ui.selectable_value(&mut adr.protocol, *prot, label);
                     }
                 });
             ui.end_row();
@@ -632,7 +632,7 @@ fn render_login_category(window: &mut MainWindow, ui: &mut egui::Ui) {
             ui.with_layout(Layout::left_to_right(egui::Align::Center), |ui| {
                 ui.add(TextEdit::singleline(
                     &mut window.get_address_mut(window.selected_bbs).password,
-                ));
+                ).password(true));
                 if ui
                     .button(RichText::new(fl!(
                         crate::LANGUAGE_LOADER,
@@ -692,11 +692,11 @@ fn render_server_catogery(window: &mut MainWindow, ui: &mut egui::Ui) {
             });
 
             egui::ComboBox::from_id_source("combobox1")
-                .selected_text(RichText::new(format!("{:?}", adr.protocol)))
+                .selected_text(RichText::new(format!("{}", adr.protocol)))
                 .show_ui(ui, |ui| {
-                    for ct in &addresses::Protocol::ALL {
-                        let label = RichText::new(format!("{ct:?}"));
-                        ui.selectable_value(&mut adr.protocol, *ct, label);
+                    for prot in &addresses::Protocol::ALL {
+                        let label = RichText::new(format!("{prot}"));
+                        ui.selectable_value(&mut adr.protocol, *prot, label);
                     }
                 });
             ui.end_row();

--- a/src/ui/dialogs/phonebook_dialog.rs
+++ b/src/ui/dialogs/phonebook_dialog.rs
@@ -630,9 +630,10 @@ fn render_login_category(window: &mut MainWindow, ui: &mut egui::Ui) {
                 )));
             });
             ui.with_layout(Layout::left_to_right(egui::Align::Center), |ui| {
-                ui.add(TextEdit::singleline(
-                    &mut window.get_address_mut(window.selected_bbs).password,
-                ).password(true));
+                ui.add(
+                    TextEdit::singleline(&mut window.get_address_mut(window.selected_bbs).password)
+                        .password(true),
+                );
                 if ui
                     .button(RichText::new(fl!(
                         crate::LANGUAGE_LOADER,

--- a/src/ui/dialogs/protocol_selector.rs
+++ b/src/ui/dialogs/protocol_selector.rs
@@ -17,7 +17,7 @@ fn create_button_row(
         if ui
             .selectable_label(
                 false,
-                RichText::new(format!("{:15}{}", title, descr)).family(egui::FontFamily::Monospace),
+                RichText::new(format!("{title:15}{descr}")).family(egui::FontFamily::Monospace),
             )
             .clicked()
         {

--- a/src/ui/terminal_window.rs
+++ b/src/ui/terminal_window.rs
@@ -468,7 +468,7 @@ impl MainWindow {
                                             .buf
                                             .get_char_xy(click_pos.x as i32, click_pos.y as i32);
                                         if let Some(ch) = ch {
-                                            println!("ch: {:?}", ch);
+                                            println!("ch: {ch:?}");
                                         }
                                     }
 


### PR DESCRIPTION
Initial WebSocket support:
* Connects to ws:// (which most people don't have) with 'WebSocket' option
* Connects to wss:// ONLY IF THE SERVER IS TRUSTED via the 'Secure WebSocket' option

In `websocket.rs` you'll see a commented line you can uncomment to test wss:// insecure. Maybe we want to make this a option in the UI, such as: "[x] Allow invalid certificates"?

Before this is merged, read_u8() and read_exact() need impl. There is also a TODO there to select the default port, but that should probably be moved to Com or something so default ports can be set if one isn't provided based on protocol.